### PR TITLE
Add `nPVI`

### DIFF
--- a/amads/time/npvi.py
+++ b/amads/time/npvi.py
@@ -1,1 +1,65 @@
-# TODO: Huw Cheston is providing some code
+"""
+Normalized pairwise variability index for notes in a Score.
+
+Author: Huw Cheston
+Date: 2025
+
+Citation: Daniele, J. R., & Patel, A. D. (2013). An Empirical Study of Historical Patterns in Musical Rhythm.
+          Music Perception, 31/1 (pp. 10-18). https://doi.org/10.1525/mp.2013.31.1.10
+          Condit-Schultz, N. (2019). Deconstructing the nPVI: A Methodological Critique of the Normalized
+          Pairwise Variability Index as Applied to Music. Music Perception, 36/3 (pp. 300–313).
+          https://doi.org/10.1525/mp.2019.36.3.300
+
+"""
+
+from typing import Iterable
+
+
+def normalized_pairwise_variability_index(durations: Iterable[float]) -> float:
+    """
+    Extracts the normalised pairwise variability index (nPVI).
+
+    The nPVI is a measure of variability between successive elements in a sequence, commonly used
+    in music analysis to quantify rhythmic variability. The equation is
+    .. math:: \text{nPVI} = \frac{100}{m-1} \times \sum\limits_{k=1}^{m-1} \left| \frac{d_k - d_{k+1}}{\frac{d_k + d_{k+1}}{2}} \right|    # noqa: W605
+       :label: nPVI
+    where :math:`n` is the number of intervals, and :math:`d_i` is the duration of the :math:`i^{th}` interval.
+
+    Parameters
+    ----------
+    durations : Iterable[float]
+        The durations to analyse
+
+    Returns
+    -------
+    float
+        The extracted nPVI value.
+
+    Examples
+    --------
+    The first example is taken from Condit-Schultz (2019, Figure 1).
+
+        >>> durs = [1., 1., 1., 1.]
+        >>> normalized_pairwise_variability_index(durations=durs)
+        0.
+
+    The second example is Daniele & Patel (2013, Appendix).
+
+        >>> durs = [1., 1/2, 1/2, 1., 1/2, 1/2, 1/3, 1/3, 1/3, 2., 1/3, 1/3, 1/3, 1/3, 1/3, 1/3, 3/2, 1., 1/2]
+        >>> x = normalized_pairwise_variability_index(durations=durs)
+        >>> round(x, 1)
+        42.2
+
+    """
+
+    numerator = (
+        sum(
+            [
+                abs((k - k1) / ((k + k1) / 2))
+                for (k, k1) in zip(durations, durations[1:])
+            ]
+        )
+        * 100
+    )
+    denominator = len(durations) - 1
+    return numerator / denominator

--- a/amads/time/npvi.py
+++ b/amads/time/npvi.py
@@ -52,6 +52,15 @@ def normalized_pairwise_variability_index(durations: Iterable[float]) -> float:
 
     """
 
+    # Explicitly check to make sure we have enough elements to calculate nPVI
+    if len(durations) < 2:
+        raise ValueError(
+            f"Must have at least 2 durations to calculate nPVI, but got {len(durations)} duration(s)"
+        )
+    # Also raise an error if any of the durations are zero or below
+    if any(d <= 0.0 for d in durations):
+        raise ValueError(f"All durations must be positive, but got {durations}!")
+
     numerator = (
         sum(
             [

--- a/tests/test_npvi.py
+++ b/tests/test_npvi.py
@@ -1,0 +1,84 @@
+"""Test suite for functions in amads.time.npvi"""
+
+import unittest
+
+from amads.time.npvi import normalized_pairwise_variability_index
+
+
+class NPVITest(unittest.TestCase):
+    def test_daniele_patel_2013_example_1(self):
+        """Tests the first example given in the Appendix of Daniele & Patel (2013, p. 18)"""
+        # This theme is from Debussy's Quartet in G Minor for Strings (1st mvmt., 2nd theme)
+        durations = [
+            1.0,
+            1 / 2,
+            1 / 2,
+            1.0,
+            1 / 2,
+            1 / 2,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            2.0,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            1 / 3,
+            3 / 2,
+            1.0,
+            1 / 2,
+        ]
+        # Values given in the paper are only reported to 1 d.p.
+        expected = 42.2
+        actual = normalized_pairwise_variability_index(durations)
+        self.assertEqual(expected, round(actual, 1))
+
+    def test_daniele_patel_2013_example_2(self):
+        """Tests the second example given in the Appendix of Daniele & Patel (2013, p. 18)"""
+        # This theme is from Elgar's Symphony No. 1 in A Flat, Op. 55 (4th mvmt., 2nd theme)
+        durations = [
+            1.0,
+            3 / 2,
+            1 / 2,
+            2 / 3,
+            2 / 3,
+            2 / 3,
+            3 / 2,
+            1 / 2,
+            3 / 2,
+            1 / 2,
+            3 / 2,
+            1 / 2,
+            2 / 3,
+            2 / 3,
+            2 / 3,
+            3 / 2,
+            1 / 2,
+            3 / 2,
+            1 / 2,
+            2 / 3,
+            2 / 3,
+            2 / 3,
+            3 / 2,
+        ]
+        # Values given in the paper are only reported to 1 d.p.
+        expected = 57.1
+        actual = normalized_pairwise_variability_index(durations)
+        self.assertEqual(expected, round(actual, 1))
+
+    def test_schultz_figure_1(self):
+        """Tests all the examples given in Figure 1 of Condit-Schultz (2019, p. 301)"""
+        all_durations = [
+            [1.0, 1.0, 1.0, 1.0],
+            [1.0, 1 / 2, 1 / 2, 1.0, 1 / 2, 1 / 2],
+            [1.0, 1 / 2, 1.0, 1 / 2],
+            [3 / 2, 1 / 2, 3 / 2, 1 / 2],
+            [7 / 16, 1 / 16, 7 / 16, 1 / 16],
+        ]
+        # Results are inconsistent in rounding, so I'm just rounding to nearest 1 d.p. here
+        expected_results = [0.0, 40.0, 66.7, 100.0, 150.0]
+        for duration, expected in zip(all_durations, expected_results):
+            actual = normalized_pairwise_variability_index(duration)
+            self.assertEqual(expected, round(actual, 1))

--- a/tests/test_npvi.py
+++ b/tests/test_npvi.py
@@ -82,3 +82,21 @@ class NPVITest(unittest.TestCase):
         for duration, expected in zip(all_durations, expected_results):
             actual = normalized_pairwise_variability_index(duration)
             self.assertEqual(expected, round(actual, 1))
+
+    def test_not_enough_durations(self):
+        """Test we raise an error with not enough durations"""
+        with self.assertRaises(ValueError):
+            bad_durations = [2.0]
+            _ = normalized_pairwise_variability_index(bad_durations)
+        with self.assertRaises(ValueError):
+            also_bad_durations = []
+            _ = normalized_pairwise_variability_index(also_bad_durations)
+
+    def test_non_positive_durations(self):
+        """Test we raise an error with negative or non-positive durations"""
+        with self.assertRaises(ValueError):
+            bad_durations = [1.0, 0.0, 3.0, 2.0]
+            _ = normalized_pairwise_variability_index(bad_durations)
+        with self.assertRaises(ValueError):
+            also_bad_durations = [3.0, 3.0, -3.0, 2.0]
+            _ = normalized_pairwise_variability_index(also_bad_durations)

--- a/tests/test_npvi.py
+++ b/tests/test_npvi.py
@@ -1,102 +1,96 @@
 """Test suite for functions in amads.time.npvi"""
 
-import unittest
+import pytest
 
 from amads.time.npvi import normalized_pairwise_variability_index
 
 
-class NPVITest(unittest.TestCase):
-    def test_daniele_patel_2013_example_1(self):
-        """Tests the first example given in the Appendix of Daniele & Patel (2013, p. 18)"""
-        # This theme is from Debussy's Quartet in G Minor for Strings (1st mvmt., 2nd theme)
-        durations = [
-            1.0,
-            1 / 2,
-            1 / 2,
-            1.0,
-            1 / 2,
-            1 / 2,
-            1 / 3,
-            1 / 3,
-            1 / 3,
-            2.0,
-            1 / 3,
-            1 / 3,
-            1 / 3,
-            1 / 3,
-            1 / 3,
-            1 / 3,
-            3 / 2,
-            1.0,
-            1 / 2,
-        ]
-        # Values given in the paper are only reported to 1 d.p.
-        expected = 42.2
+def test_daniele_patel_2013_example_1():
+    """Tests the first example given in the Appendix of Daniele & Patel (2013, p. 18)"""
+    durations = [
+        1.0,
+        1 / 2,
+        1 / 2,
+        1.0,
+        1 / 2,
+        1 / 2,
+        1 / 3,
+        1 / 3,
+        1 / 3,
+        2.0,
+        1 / 3,
+        1 / 3,
+        1 / 3,
+        1 / 3,
+        1 / 3,
+        1 / 3,
+        3 / 2,
+        1.0,
+        1 / 2,
+    ]
+    expected = 42.2
+    actual = normalized_pairwise_variability_index(durations)
+    assert round(actual, 1) == expected
+
+
+def test_daniele_patel_2013_example_2():
+    """Tests the second example given in the Appendix of Daniele & Patel (2013, p. 18)"""
+    durations = [
+        1.0,
+        3 / 2,
+        1 / 2,
+        2 / 3,
+        2 / 3,
+        2 / 3,
+        3 / 2,
+        1 / 2,
+        3 / 2,
+        1 / 2,
+        3 / 2,
+        1 / 2,
+        2 / 3,
+        2 / 3,
+        2 / 3,
+        3 / 2,
+        1 / 2,
+        3 / 2,
+        1 / 2,
+        2 / 3,
+        2 / 3,
+        2 / 3,
+        3 / 2,
+    ]
+    expected = 57.1
+    actual = normalized_pairwise_variability_index(durations)
+    assert round(actual, 1) == expected
+
+
+def test_schultz_figure_1():
+    """Tests all the examples given in Figure 1 of Condit-Schultz (2019, p. 301)"""
+    all_durations = [
+        [1.0, 1.0, 1.0, 1.0],
+        [1.0, 1 / 2, 1 / 2, 1.0, 1 / 2, 1 / 2],
+        [1.0, 1 / 2, 1.0, 1 / 2],
+        [3 / 2, 1 / 2, 3 / 2, 1 / 2],
+        [7 / 16, 1 / 16, 7 / 16, 1 / 16],
+    ]
+    expected_results = [0.0, 40.0, 66.7, 100.0, 150.0]
+    for durations, expected in zip(all_durations, expected_results):
         actual = normalized_pairwise_variability_index(durations)
-        self.assertEqual(expected, round(actual, 1))
+        assert round(actual, 1) == expected
 
-    def test_daniele_patel_2013_example_2(self):
-        """Tests the second example given in the Appendix of Daniele & Patel (2013, p. 18)"""
-        # This theme is from Elgar's Symphony No. 1 in A Flat, Op. 55 (4th mvmt., 2nd theme)
-        durations = [
-            1.0,
-            3 / 2,
-            1 / 2,
-            2 / 3,
-            2 / 3,
-            2 / 3,
-            3 / 2,
-            1 / 2,
-            3 / 2,
-            1 / 2,
-            3 / 2,
-            1 / 2,
-            2 / 3,
-            2 / 3,
-            2 / 3,
-            3 / 2,
-            1 / 2,
-            3 / 2,
-            1 / 2,
-            2 / 3,
-            2 / 3,
-            2 / 3,
-            3 / 2,
-        ]
-        # Values given in the paper are only reported to 1 d.p.
-        expected = 57.1
-        actual = normalized_pairwise_variability_index(durations)
-        self.assertEqual(expected, round(actual, 1))
 
-    def test_schultz_figure_1(self):
-        """Tests all the examples given in Figure 1 of Condit-Schultz (2019, p. 301)"""
-        all_durations = [
-            [1.0, 1.0, 1.0, 1.0],
-            [1.0, 1 / 2, 1 / 2, 1.0, 1 / 2, 1 / 2],
-            [1.0, 1 / 2, 1.0, 1 / 2],
-            [3 / 2, 1 / 2, 3 / 2, 1 / 2],
-            [7 / 16, 1 / 16, 7 / 16, 1 / 16],
-        ]
-        # Results are inconsistent in rounding, so I'm just rounding to nearest 1 d.p. here
-        expected_results = [0.0, 40.0, 66.7, 100.0, 150.0]
-        for duration, expected in zip(all_durations, expected_results):
-            actual = normalized_pairwise_variability_index(duration)
-            self.assertEqual(expected, round(actual, 1))
+def test_not_enough_durations():
+    """Test we raise an error with not enough durations"""
+    with pytest.raises(ValueError):
+        normalized_pairwise_variability_index([2.0])
+    with pytest.raises(ValueError):
+        normalized_pairwise_variability_index([])
 
-    def test_not_enough_durations(self):
-        """Test we raise an error with not enough durations"""
-        with self.assertRaises(ValueError):
-            bad_durations = [2.0]
-            _ = normalized_pairwise_variability_index(bad_durations)
-        with self.assertRaises(ValueError):
-            also_bad_durations = []
-            _ = normalized_pairwise_variability_index(also_bad_durations)
 
-    def test_non_positive_durations(self):
-        """Test we raise an error with negative or non-positive durations"""
-        with self.assertRaises(ValueError):
-            bad_durations = [1.0, 0.0, 3.0, 2.0]
-            _ = normalized_pairwise_variability_index(bad_durations)
-        with self.assertRaises(ValueError):
-            also_bad_durations = [3.0, 3.0, -3.0, 2.0]
-            _ = normalized_pairwise_variability_index(also_bad_durations)
+def test_non_positive_durations():
+    """Test we raise an error with negative or non-positive durations"""
+    with pytest.raises(ValueError):
+        normalized_pairwise_variability_index([1.0, 0.0, 3.0, 2.0])
+    with pytest.raises(ValueError):
+        normalized_pairwise_variability_index([3.0, 3.0, -3.0, 2.0])


### PR DESCRIPTION
This PR is the first of several that should split up the timing features introduced in https://github.com/music-computing/amads/pull/12 into multiple separate PRs. The hope is that this should be easier to keep track of discussions than a single large PR!

This PR implements `npvi.py` and adds related tests. It should also resolve all related comments from the previous PR.