### PR TITLE
Bugfix `npvi` docstring crashing `sphinx`

### DIFF
--- a/amads/time/npvi.py
+++ b/amads/time/npvi.py
@@ -15,41 +15,42 @@ Citation: Daniele, J. R., & Patel, A. D. (2013). An Empirical Study of Historica
 from typing import Iterable
 
 
-def normalized_pairwise_variability_index(durations: Iterable[float]) -> float:
+# flake8: noqa: W605
+def normalized_pairwise_variability_index(
+    durations: Iterable[float],
+) -> float:
     """
     Extracts the normalised pairwise variability index (nPVI).
 
     The nPVI is a measure of variability between successive elements in a sequence, commonly used
-    in music analysis to quantify rhythmic variability. The equation is
-    .. math:: \text{nPVI} = \frac{100}{m-1} \times \sum\limits_{k=1}^{m-1} \left| \frac{d_k - d_{k+1}}{\frac{d_k + d_{k+1}}{2}} \right|    # noqa: W605
-       :label: nPVI
-    where :math:`n` is the number of intervals, and :math:`d_i` is the duration of the :math:`i^{th}` interval.
+    in music analysis to quantify rhythmic variability. The equation is:
 
-    Parameters
-    ----------
-    durations : Iterable[float]
-        The durations to analyse
+    .. math::
 
-    Returns
-    -------
-    float
-        The extracted nPVI value.
+       \text{nPVI} = \frac{100}{m-1} \times \sum\limits_{k=1}^{m-1}
+       \left| \frac{d_k - d_{k+1}}{\frac{d_k + d_{k+1}}{2}} \right|
 
-    Examples
-    --------
-    The first example is taken from Condit-Schultz (2019, Figure 1).
+    where :math:`m` is the number of intervals, and :math:`d_k` is the duration of the :math:`k^{th}` interval.
+
+    Args:
+        durations (Iterable[float]): the durations to analyse
+
+    Returns:
+        float: the extracted nPVI value.
+
+    Examples:
+        The first example is taken from Condit-Schultz (2019, Figure 1).
 
         >>> durs = [1., 1., 1., 1.]
         >>> normalized_pairwise_variability_index(durations=durs)
         0.
 
-    The second example is Daniele & Patel (2013, Appendix).
+        The second example is Daniele & Patel (2013, Appendix).
 
         >>> durs = [1., 1/2, 1/2, 1., 1/2, 1/2, 1/3, 1/3, 1/3, 2., 1/3, 1/3, 1/3, 1/3, 1/3, 1/3, 3/2, 1., 1/2]
         >>> x = normalized_pairwise_variability_index(durations=durs)
         >>> round(x, 1)
         42.2
-
     """
 
     # Explicitly check to make sure we have enough elements to calculate nPVI

--- a/amads/time/npvi.py
+++ b/amads/time/npvi.py
@@ -1,25 +1,32 @@
 """
-Normalized pairwise variability index for notes in a Score.
+Normalized Pairwise Variability Index (nPVI).
 
-Author: Huw Cheston
-Date: 2025
+This module provides functions for calculating the normalized pairwise variability
+index (nPVI), a measure used in the analysis of rhythmic variability in music.
 
-Citation: Daniele, J. R., & Patel, A. D. (2013). An Empirical Study of Historical Patterns in Musical Rhythm.
-          Music Perception, 31/1 (pp. 10-18). https://doi.org/10.1525/mp.2013.31.1.10
-          Condit-Schultz, N. (2019). Deconstructing the nPVI: A Methodological Critique of the Normalized
-          Pairwise Variability Index as Applied to Music. Music Perception, 36/3 (pp. 300–313).
-          https://doi.org/10.1525/mp.2019.36.3.300
+References:
+    - Daniele, J. R., & Patel, A. D. (2013). An Empirical Study of Historical Patterns
+      in Musical Rhythm. Music Perception, 31(1), 10-18.
+      https://doi.org/10.1525/mp.2013.31.1.10
 
+    - Condit-Schultz, N. (2019). Deconstructing the nPVI: A Methodological Critique of
+      the Normalized Pairwise Variability Index as Applied to Music. Music Perception,
+      36(3), 300–313. https://doi.org/10.1525/mp.2019.36.3.300
+
+Author:
+    Huw Cheston (2025)
 """
 
 from typing import Iterable
+
+__author__ = "Huw Cheston"
 
 
 # flake8: noqa: W605
 def normalized_pairwise_variability_index(
     durations: Iterable[float],
 ) -> float:
-    """
+    r"""
     Extracts the normalised pairwise variability index (nPVI).
 
     The nPVI is a measure of variability between successive elements in a sequence, commonly used


### PR DESCRIPTION
Currently the docstring for `npvi` is crashing the documentation build with `sphinx`. This I believe is due to the numpy style docstring:

```
Parameters
------------
```
crashing due to adding an unexpected section in RST format. 

This fix just removes the numpy style docstring and allows the documentation build to work properly on my machine at least. ~~I've also noted that the equation isn't properly formatting, however, and would welcome any thoughts on that from @pmcharrison @MarkGotham~~

In the future, I think we should add building the documentation as part of the PR process to avoid this from happening again.
