### PR TITLE
Add `swing.py`

### DIFF
--- a/amads/time/swing.py
+++ b/amads/time/swing.py
@@ -62,25 +62,52 @@ def beat_upbeat_ratio(
     Additionally, the function can calculate the :math:`log_2` of the BUR values, where a value of 0.0
     corresponds to "triplet" swing. This can be enabled by setting `log2=True`. The values can also
     be filtered to remove outliers by setting `bounded=True`, with the default values for the boundaries
-    coming from Corcoran & Frieler (2021)
+    coming from Corcoran & Frieler (2021).
 
-    Args:
-        beats (Iterable[float]):
-            An array of beat timestamps. Should not overlap with `upbeats`.
-        upbeats (Iterable[float]):
-            An array of upbeat timestamps.
-        log2 (bool, optional):
-            If True, computes the log base 2 of BUR values, as used in [2]. Defaults to False.
-        bounded (bool, optional):
-            If True, filters out BUR values outside the specified range. Defaults to False.
-        lower_bound (float, optional):
-            Lower boundary for filtering BUR values. Defaults to 0.25 (:math:`log_2` -2).
-        upper_bound (float, optional):
-            Upper boundary for filtering BUR values. Defaults to 4.0 (:math:`log_2` 2).
+    Parameters
+    ----------
+    beats : Iterable[float]
+        An array of beat timestamps. Should not overlap with `upbeats`.
+    upbeats : Iterable[float]
+        An array of upbeat timestamps.
+    log2 : bool, optional
+        If True, computes the log base 2 of BUR values, as used in [2]. Defaults to False.
+    bounded : bool, optional
+        If True, filters out BUR values outside the specified range. Defaults to False.
+    lower_bound : float, optional
+        Lower boundary for filtering BUR values. Defaults to 0.25 (:math:`log_2` -2).
+    upper_bound : float, optional
+        Upper boundary for filtering BUR values. Defaults to 4.0 (:math:`log_2` 2).
 
-    Returns:
-        list[float]:
-            A list of the calculated BUR values.
+    Returns
+    -------
+    list[float]
+        A list of the calculated BUR values.
+
+    Examples
+    --------
+    >>> my_beats = [0., 1., 2., 3.]
+    >>> my_upbeats = [0.5, 1.75, 2.2]
+    >>> beat_upbeat_ratio(my_beats, my_upbeats)
+    [1., 3., 0.25]
+
+    >>> # Consecutive beats without a matching upbeat will be skipped.
+    >>> my_beats = [0., 1., 2., 3.]
+    >>> my_upbeats = [0.5, 2.2]
+    >>> beat_upbeat_ratio(my_beats, my_upbeats)
+    [1., None, 0.25]
+
+    >>> # Consecutive beats with multiple matching upbeats will be skipped.
+    >>> my_beats = [0., 1., 2., 3.]
+    >>> my_upbeats = [0.5, 1.5, 1.75, 1.8, 2.2]
+    >>> beat_upbeat_ratio(my_beats, my_upbeats)
+    [1., None, 0.25]
+
+    >>> # Filter out outlying values by setting `bounded=True`.
+    >>> my_beats = [0., 1., 2., 3.]
+    >>> my_upbeats = [0.5, 1.75, 2.99]
+    >>> beat_upbeat_ratio(my_beats, my_upbeats)
+    [1., 3., None]
 
     """
 

--- a/amads/time/swing.py
+++ b/amads/time/swing.py
@@ -20,7 +20,7 @@ import numpy as np
 
 __author__ = "Huw Cheston"
 
-TINY = 1e-4
+TINY = 1e-8
 LOW_BUR, HIGH_BUR = (
     0.25,
     4.0,
@@ -50,7 +50,7 @@ def beat_upbeat_ratio(
     .. math::
         \text{BUR} = \frac{t_{a,b} - t_{a}}{t_{b} - t_{a,b}},
 
-    where :math:`t_a` is the beat at position :math:`a`, math:`t_b` is the beat at position :math:`b`,
+    where :math:`t_a` is the beat at position :math:`a`, :math:`t_b` is the beat at position :math:`b`,
     and :math:`t_{a,b}` is the single upbeat between beats :math:`a` and :math:`b`.
 
     The function takes two iterables of timestamps: `beats` and `upbeats`. Both lists should be
@@ -65,9 +65,9 @@ def beat_upbeat_ratio(
     coming from Corcoran & Frieler (2021)
 
     Args:
-        beats (Iterable):
+        beats (Iterable[float]):
             An array of beat timestamps. Should not overlap with `upbeats`.
-        upbeats (Iterable):
+        upbeats (Iterable[float]):
             An array of upbeat timestamps.
         log2 (bool, optional):
             If True, computes the log base 2 of BUR values, as used in [2]. Defaults to False.
@@ -137,7 +137,7 @@ def _validate_bur_inputs(beats: np.ndarray, upbeats: np.ndarray) -> None:
 
 
 def match_beats_and_upbeats(beats: np.ndarray, upbeats: np.ndarray) -> np.ndarray:
-    """Iterates over consecutive beats and creates an array of [[beat1, upbeat, beat2], [beat2, upbeat, beat3]]"""
+    """Iterates over consecutive beats and creates an array of `[[beat1, upbeat, beat2], [beat2, upbeat, beat3]]`"""
 
     matched = []
     # Iterate over consecutive pairs of beats

--- a/amads/time/swing.py
+++ b/amads/time/swing.py
@@ -113,12 +113,16 @@ def beat_upbeat_ratio(
 
 def mean_bur(beats: Iterable[float], upbeats: Iterable[float], **kwargs) -> float:
     """Calculates mean BUR (or :math:`log_2` BUR) given a list of beats and upbeats"""
-    return float(np.mean(beat_upbeat_ratio(beats, upbeats, **kwargs)))
+    # We use nanmean here as we may have null values in cases where multiple upbeats match with a
+    #  single pair of beats, or where no upbeats match with a beat.
+    #  I think this makes sense to avoid the user having to chop a large list into multiple sublists
+    #  depending on the presence of nans.
+    return float(np.nanmean(beat_upbeat_ratio(beats, upbeats, **kwargs)))
 
 
 def std_bur(beats: Iterable[float], upbeats: Iterable[float], **kwargs) -> float:
     """Calculates standard deviation BUR (or :math:`log_2` BUR) given a list of beats and upbeats"""
-    return np.std(beat_upbeat_ratio(beats, upbeats, **kwargs))
+    return np.nanstd(beat_upbeat_ratio(beats, upbeats, **kwargs))
 
 
 def _validate_bur_inputs(beats: np.ndarray, upbeats: np.ndarray) -> None:

--- a/amads/time/swing.py
+++ b/amads/time/swing.py
@@ -106,7 +106,7 @@ def beat_upbeat_ratio(
     >>> # Filter out outlying values by setting `bounded=True`.
     >>> my_beats = [0., 1., 2., 3.]
     >>> my_upbeats = [0.5, 1.75, 2.99]
-    >>> beat_upbeat_ratio(my_beats, my_upbeats)
+    >>> beat_upbeat_ratio(my_beats, my_upbeats, bounded=True)
     [1., 3., None]
 
     """

--- a/amads/time/swing.py
+++ b/amads/time/swing.py
@@ -1,1 +1,168 @@
-# TODO: Huw Cheston is providing some code
+"""
+This module implements various functions useful for analyzing swing in jazz and other genres.
+
+References:
+    - Benadon, F. (2006). Slicing the Beat: Jazz Eighth-Notes as Expressive Microrhythm.
+      Ethnomusicology, 50(1), 73–98. https://doi.org/10.2307/20174424
+    - Corcoran, C., & Frieler, K. (2021). Playing It Straight: Analyzing Jazz Soloists’ Swing
+      Eighth-Note Distributions with the Weimar Jazz Database. Music Perception, 38(4), 372–385.
+      https://doi.org/10.1525/mp.2021.38.4.372
+
+Author:
+    Huw Cheston (2025)
+
+"""
+
+from math import log2 as log2_
+from typing import Iterable
+
+import numpy as np
+
+__author__ = "Huw Cheston"
+
+TINY = 1e-4
+LOW_BUR, HIGH_BUR = (
+    0.25,
+    4.0,
+)  # the range of BURs to keep as defined in Corcoran & Frieler (2021)
+
+
+# flake8: noqa: W605
+def beat_upbeat_ratio(
+    beats: Iterable[float],
+    upbeats: Iterable[float],
+    log2: bool = False,
+    bounded: bool = False,
+    lower_bound: float = LOW_BUR,
+    upper_bound: float = HIGH_BUR,
+) -> list[float]:
+    r"""
+    Extracts beat-upbeat ratio (BUR) values from an array of beats and upbeats.
+
+    The beat-upbeat ratio (BUR) is used to analyze the amount of "swing" in two consecutive
+    eighth-note beat durations. It is calculated by dividing the duration of the first ("long")
+    eighth-note beat by the duration of the second ("short") eighth-note beat. A BUR value of 2
+    represents "perfect" swing (e.g., a triplet quarter note followed by a triplet eighth note),
+    while a BUR of 1 represents "even" eighth-note durations.
+
+    The formula for BUR is:
+
+    .. math::
+        \text{BUR} = \frac{t_{a,b} - t_{a}}{t_{b} - t_{a,b}},
+
+    where :math:`t_a` is the beat at position :math:`a`, math:`t_b` is the beat at position :math:`b`,
+    and :math:`t_{a,b}` is the single upbeat between beats :math:`a` and :math:`b`.
+
+    The function takes two iterables of timestamps: `beats` and `upbeats`. Both lists should be
+    unique, and missing values should not be present. The function returns an array of BUR values with
+    a size of `len(beats) - 1`. If multiple `upbeats` are found between two consecutive `beats`
+    or if no `upbeat` is found, the BUR for those beats will be omitted and the corresponding value
+    will be `None`.
+
+    Additionally, the function can calculate the :math:`log_2` of the BUR values, where a value of 0.0
+    corresponds to "triplet" swing. This can be enabled by setting `log2=True`. The values can also
+    be filtered to remove outliers by setting `bounded=True`, with the default values for the boundaries
+    coming from Corcoran & Frieler (2021)
+
+    Args:
+        beats (Iterable):
+            An array of beat timestamps. Should not overlap with `upbeats`.
+        upbeats (Iterable):
+            An array of upbeat timestamps.
+        log2 (bool, optional):
+            If True, computes the log base 2 of BUR values, as used in [2]. Defaults to False.
+        bounded (bool, optional):
+            If True, filters out BUR values outside the specified range. Defaults to False.
+        lower_bound (float, optional):
+            Lower boundary for filtering BUR values. Defaults to 0.25 (:math:`log_2` -2).
+        upper_bound (float, optional):
+            Upper boundary for filtering BUR values. Defaults to 4.0 (:math:`log_2` 2).
+
+    Returns:
+        list[float]:
+            A list of the calculated BUR values.
+
+    """
+
+    # Parse beats and upbeats to an array, sorting as required
+    beats = np.sort(np.array(beats))
+    upbeats = np.sort(np.array(upbeats))
+    # Validate inputs and raise an errors if required
+    _validate_bur_inputs(beats, upbeats)
+    # Match beats with upbeats and return a 2d array of shape [[beat1, upbeat, beat2], [beat2, upbeat, beat3]]
+    matched = match_beats_and_upbeats(beats, upbeats)
+    # Raise an error if we cannot find any matches between beats and upbeats
+    if all([np.isnan(i) for i in matched[:, 1]]):
+        raise ValueError(
+            "No matches found between beats and upbeats, cannot calculate BUR"
+        )
+    # Calculate the BUR for upbeats between consecutive beats
+    burs = [
+        _bur(b1, upbeat, b2) if not np.isnan(upbeat) else None
+        for b1, upbeat, b2 in matched
+    ]
+    # Apply our filtering if required
+    # Filter before log_2 transform to make things simpler
+    if bounded:
+        burs = [i if lower_bound < i < upper_bound else None for i in burs]
+    # Express as base-2 log if required
+    if log2:
+        burs = [log2_(b) if b is not None else None for b in burs]
+    return burs
+
+
+def mean_bur(beats: Iterable[float], upbeats: Iterable[float], **kwargs) -> float:
+    """Calculates mean BUR (or :math:`log_2` BUR) given a list of beats and upbeats"""
+    return float(np.mean(beat_upbeat_ratio(beats, upbeats, **kwargs)))
+
+
+def std_bur(beats: Iterable[float], upbeats: Iterable[float], **kwargs) -> float:
+    """Calculates standard deviation BUR (or :math:`log_2` BUR) given a list of beats and upbeats"""
+    return np.std(beat_upbeat_ratio(beats, upbeats, **kwargs))
+
+
+def _validate_bur_inputs(beats: np.ndarray, upbeats: np.ndarray) -> None:
+    """Validate beats and upbeats before calculating BURs"""
+    if len(beats) < 2:
+        raise ValueError("Must have at least two beats to calculate BURs")
+    if len(upbeats) < 1:
+        raise ValueError("Must have at least one upbeat to calculate BURs")
+    if len(beats.shape) > 1 or len(upbeats.shape) > 1:
+        raise ValueError("Beats and upbeats must be one-dimensional arrays")
+    if np.isnan(np.sum(beats)) or np.isnan(np.sum(upbeats)):
+        raise ValueError("Missing values found in beats or upbeats")
+    for b1 in beats:
+        if any(np.isclose(b1, upbeats, atol=TINY)):
+            raise ValueError("Intersection found between beats and upbeats")
+
+
+def match_beats_and_upbeats(beats: np.ndarray, upbeats: np.ndarray) -> np.ndarray:
+    """Iterates over consecutive beats and creates an array of [[beat1, upbeat, beat2], [beat2, upbeat, beat3]]"""
+
+    matched = []
+    # Iterate over consecutive pairs of beats
+    for b1, b2 in zip(beats, beats[1:]):
+        # Get the upbeats that are between both pairs of beats
+        upbeat_bw = upbeats[(b1 < upbeats) & (upbeats < b2)]
+        # Add a missing value in cases where multiple upbeats match with a single pair of beats, or no upbeats match
+        #  We do not consider cases where multiple upbeats match with a single beat, as these are not "swing 8ths"
+        #  Adding a missing value means that we'll have the shape len(beats) - 1
+        if len(upbeat_bw) > 1 or len(upbeat_bw) == 0:
+            matched.append([b1, None, b2])
+        # This will only catch cases where we have matched a single upbeat
+        else:
+            matched.append([b1, upbeat_bw[0], b2])
+    # Create a 2d array of [[beat1, upbeat, beat2], [beat2, upbeat, beat3]]
+    return np.array(matched, dtype=float)
+
+
+def _bur(beat1: float, upbeat: float, beat2: float) -> float:
+    """BUR calculation function. Takes in two consecutive beats and gets BURs from provided upbeats."""
+
+    # Everything should be in order
+    assert beat1 - TINY < upbeat < beat2 + TINY
+    # Calculate IOIs
+    ioi1 = upbeat - beat1
+    ioi2 = beat2 - upbeat
+    # Calculate BUR
+    return ioi1 / ioi2

--- a/docs/developer_notes/documentation.rst
+++ b/docs/developer_notes/documentation.rst
@@ -10,6 +10,7 @@ Before building the documentation, ensure you have the dev dependencies installe
 
 .. code-block:: bash
 
+    pip install sphinx-autobuild
     pip install -e ".[dev]"
 
 Building documentation

--- a/tests/test_swing.py
+++ b/tests/test_swing.py
@@ -1,0 +1,132 @@
+"""Test suite for amads.time.swing.py"""
+
+import numpy as np
+import pytest
+
+from amads.time.swing import _validate_bur_inputs, beat_upbeat_ratio, mean_bur, std_bur
+
+TEST_BEATS = [
+    [0.0, 1.0, 2.0],
+    [0.0, 1.0, 2.0, 3.0, 4.0],
+    [0.0, 1.3, 2.2, 3.3, 5.5, 6.1],
+]
+TEST_UPBEATS = [
+    [0.6, 1.4],  # example 1, straightforward
+    [0.5, 1.2, 2.6, 3.5, 4.9],  # example 2, slightly harder
+    [
+        0.5,
+        1.2,
+        2.7,
+        3.5,
+        3.6,
+    ],  # example 3: b1 + b4 skipped as two upbeats, b2 + b5 skipped as have no upbeat
+]
+TEST_BURS = [[1.5, 2 / 3], [1.0, 0.25, 1.5, 1.0], [None, None, 0.5 / 0.6, None, None]]
+
+
+@pytest.mark.parametrize(
+    "beats,upbeats,expecteds", zip(TEST_BEATS, TEST_UPBEATS, TEST_BURS)
+)
+def test_bur(beats, upbeats, expecteds):
+    burs = beat_upbeat_ratio(beats, upbeats)
+    assert pytest.approx(burs) == expecteds
+    assert len(burs) == len(beats) - 1
+
+
+def test_validate_bur_inputs():
+    # Test 1: Valid inputs
+    beats = np.array([1.0, 2.0, 3.0])
+    upbeats = np.array([1.5])
+    try:
+        _validate_bur_inputs(beats, upbeats)
+    except ValueError:
+        pytest.fail("ValueError raised unexpectedly with valid inputs")
+
+    # Test 2: Invalid input - Less than two beats
+    beats = np.array([1.0])
+    upbeats = np.array([1.5])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 3: Invalid input - No upbeats
+    beats = np.array([1.0, 2.0, 3.0])
+    upbeats = np.array([])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 4: Invalid input - Multi-dimensional beats
+    beats = np.array([[1.0, 2.0], [3.0, 4.0]])
+    upbeats = np.array([1.5])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 5: Invalid input - Multi-dimensional upbeats
+    beats = np.array([1.0, 2.0, 3.0])
+    upbeats = np.array([[1.5]])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 6: Invalid input - NaN in beats
+    beats = np.array([1.0, np.nan, 3.0])
+    upbeats = np.array([1.5])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 7: Invalid input - NaN in upbeats
+    beats = np.array([1.0, 2.0, 3.0])
+    upbeats = np.array([np.nan])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+    # Test 8: Invalid input - Intersection between beats and upbeats
+    beats = np.array([1.0, 2.0, 3.0])
+    upbeats = np.array([2.0])
+    with pytest.raises(ValueError):
+        _validate_bur_inputs(beats, upbeats)
+
+
+def test_no_matches():
+    beats = [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+    ]
+    upbeats = [5.0, 6.0, 7.0, 8.0]
+    with pytest.raises(ValueError):
+        _ = beat_upbeat_ratio(beats, upbeats)
+
+
+def test_bounded_burs():
+    beats = [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+    ]
+    upbeats = [0.5, 1.5, 2.99]
+    expected = [1.0, 1.0, None]
+    actual = beat_upbeat_ratio(beats, upbeats, bounded=True)
+    assert pytest.approx(actual) == expected
+
+
+def test_log2_burs():
+    beats = [0.0, 1.0, 2.0, 3.0]
+    upbeats = [1 / 3, 5 / 3, 2.5]
+    expected = [-1.0, 1.0, 0.0]
+    actual = beat_upbeat_ratio(beats, upbeats, log2=True)
+    assert pytest.approx(actual) == expected
+
+
+def test_agg_funcs():
+    beats = [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+    ]
+    upbeats = [0.5, 1.75, 2.8]
+    mean = 8 / 3  # burs = [1., 3., 4.]
+    sd = 1.247219
+    assert pytest.approx(mean_bur(beats, upbeats)) == mean
+    assert pytest.approx(std_bur(beats, upbeats)) == sd

--- a/tests/test_swing.py
+++ b/tests/test_swing.py
@@ -34,51 +34,43 @@ def test_bur(beats, upbeats, expecteds):
 
 
 def test_validate_bur_inputs():
-    # Test 1: Valid inputs
-    beats = np.array([1.0, 2.0, 3.0])
-    upbeats = np.array([1.5])
-    try:
-        _validate_bur_inputs(beats, upbeats)
-    except ValueError:
-        pytest.fail("ValueError raised unexpectedly with valid inputs")
-
-    # Test 2: Invalid input - Less than two beats
+    # Test 1: Invalid input - Less than two beats
     beats = np.array([1.0])
     upbeats = np.array([1.5])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 3: Invalid input - No upbeats
+    # Test 2: Invalid input - No upbeats
     beats = np.array([1.0, 2.0, 3.0])
     upbeats = np.array([])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 4: Invalid input - Multi-dimensional beats
+    # Test 3: Invalid input - Multi-dimensional beats
     beats = np.array([[1.0, 2.0], [3.0, 4.0]])
     upbeats = np.array([1.5])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 5: Invalid input - Multi-dimensional upbeats
+    # Test 4: Invalid input - Multi-dimensional upbeats
     beats = np.array([1.0, 2.0, 3.0])
     upbeats = np.array([[1.5]])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 6: Invalid input - NaN in beats
+    # Test 5: Invalid input - NaN in beats
     beats = np.array([1.0, np.nan, 3.0])
     upbeats = np.array([1.5])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 7: Invalid input - NaN in upbeats
+    # Test 6: Invalid input - NaN in upbeats
     beats = np.array([1.0, 2.0, 3.0])
     upbeats = np.array([np.nan])
     with pytest.raises(ValueError):
         _validate_bur_inputs(beats, upbeats)
 
-    # Test 8: Invalid input - Intersection between beats and upbeats
+    # Test 7: Invalid input - Intersection between beats and upbeats
     beats = np.array([1.0, 2.0, 3.0])
     upbeats = np.array([2.0])
     with pytest.raises(ValueError):


### PR DESCRIPTION
This is the final PR derived from https://github.com/music-computing/amads/pull/12 that adds `swing.py` and functions related to `beat_upbeat_ratio`. Compared with the previous implementation, this works by:

- Taking in an iterables of `beats` and `upbeats`
- We leave the handling of which onsets are beats and which are upbeats up to the user as it isn't currently clear to me how we want to handle this.
- Validating both iterables (checking for not enough values, missing values, overlapping values)
- Matching consecutive beats and upbeats together:
- In cases where more than one `upbeat` can be matched with two consecutive `beats` (or no `upbeats` can be matched with them), we skip over these cases: as @pmcharrison points out in https://github.com/music-computing/amads/pull/12#discussion_r1880963470, this "multiple upbeats" situation can't really be considered swing 8ths.
- Calculating the BUR for all valid cases, adding in None for invalid cases
- Returning an array with size == `len(beats) - 1`. 

There are two utility functions which just calculate mean and SD BUR from a list of beats + upbeats. Note that these use `np.nanmean` to handle `null` values: I think this makes sense personally, as it means the user does not need to chop up a large list of beats/upbeats into multiple sublists and then call `mean_bur` on each of these. Others may disagree, however!