### PR TITLE
Fix issues creating docs

### DIFF
--- a/amads/time/variability.py
+++ b/amads/time/variability.py
@@ -58,66 +58,65 @@ def normalized_pairwise_variability_index(
     durations: Iterable[float],
 ) -> float:
     r"""
-     Calculates the normalised pairwise variability index (nPVI).
+    Calculates the normalised pairwise variability index (nPVI).
 
-     The nPVI is a measure of variability between successive elements in a sequence.
+    The nPVI is a measure of variability between successive elements in a sequence.
 
-     The equation is:
+    The equation is:
 
-     .. math::
+    .. math::
 
         \text{nPVI} = \frac{100}{m-1} \times \sum\limits_{k=1}^{m-1}
         \left| \frac{d_k - d_{k+1}}{\frac{d_k + d_{k+1}}{2}} \right|
 
-     where :math:`m` is the number of intervals, and :math:`d_k` is the duration of the :math:`k^{th}` interval.
+    where :math:`m` is the number of intervals, and :math:`d_k` is the duration of the :math:`k^{th}` interval.
 
-     A completely regular stream of equal durations returns 0 variability.
-     High difference between successive items returns a high nPVI value
-     irrespective of other (e.g., metrical) considerations.
+    A completely regular stream of equal durations returns 0 variability.
+    High difference between successive items returns a high nPVI value
+    irrespective of other (e.g., metrical) considerations.
 
-     Parameters
-     ----------
-     durations (Iterable[float]): the durations to analyse
+    Parameters
+    ----------
+    durations (Iterable[float]): the durations to analyse
 
-     Returns
-     -------
-     float: the extracted nPVI value.
+    Returns
+    -------
+    float: the extracted nPVI value.
 
-     Examples
-     -------
+    Examples
+    -------
 
-     A completely regular stream of equal durations returns 0 variability.
+    A completely regular stream of equal durations returns 0 variability.
 
-     >>> normalized_pairwise_variability_index([1., 1., 1., 1.])
-     0.
+    >>> normalized_pairwise_variability_index([1., 1., 1., 1.])
+    0.
 
-     This example is from Daniele & Patel (2013, Appendix).
+    This example is from Daniele & Patel (2013, Appendix).
 
-     >>> durs = [1., 1/2, 1/2, 1., 1/2, 1/2, 1/3, 1/3, 1/3, 2., 1/3, 1/3, 1/3, 1/3, 1/3, 1/3, 3/2, 1., 1/2]
-     >>> x = normalized_pairwise_variability_index(durations=durs)
-     >>> round(x, 1)
-     42.2
+    >>> durs = [1., 1/2, 1/2, 1., 1/2, 1/2, 1/3, 1/3, 1/3, 2., 1/3, 1/3, 1/3, 1/3, 1/3, 1/3, 3/2, 1., 1/2]
+    >>> x = normalized_pairwise_variability_index(durations=durs)
+    >>> round(x, 1)
+    42.2
 
     These next examples are from Condit-Schultz's 2019 critique (Figure 2).
 
-     >>> normalized_pairwise_variability_index([0.25, 0.25, 0.25, 0.25, 1., 0.25, 0.25, 0.25, 0.25, 1.])
-     40.
+    >>> normalized_pairwise_variability_index([0.25, 0.25, 0.25, 0.25, 1., 0.25, 0.25, 0.25, 0.25, 1.])
+    40.
 
-     >>> normalized_pairwise_variability_index([0.25, 0.25, 0.5, 1., 0.25, 0.25, 0.5, 1.])
-     55.2
+    >>> normalized_pairwise_variability_index([0.25, 0.25, 0.5, 1., 0.25, 0.25, 0.5, 1.])
+    55.2
 
-     >>> normalized_pairwise_variability_index([0.5, 0.25, 0.25, 1., 0.5, 0.25, 0.25, 1.])
-     62.8
+    >>> normalized_pairwise_variability_index([0.5, 0.25, 0.25, 1., 0.5, 0.25, 0.25, 1.])
+    62.8
 
-     >>> normalized_pairwise_variability_index([2, 1, 2, 1])
-     66.66
+    >>> normalized_pairwise_variability_index([2, 1, 2, 1])
+    66.66
 
-     >>> normalized_pairwise_variability_index([0.5, 1, 2, 1, 0.5])
-     66.66
+    >>> normalized_pairwise_variability_index([0.5, 1, 2, 1, 0.5])
+    66.66
 
-     >>> normalized_pairwise_variability_index([2, 1, 0.5, 1, 0.5, 0.25])
-     66.66
-
+    >>> normalized_pairwise_variability_index([2, 1, 0.5, 1, 0.5, 0.25])
+    66.66
 
     """
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,12 +46,9 @@ General algorithms
 .. autosummary::
    :toctree: _autosummary
    :caption: General algorithms:
+   :recursive:
 
-   amads.algorithms.entropy
-   amads.algorithms.nnotes
-   amads.algorithms.scale
-   amads.algorithms.slice.salami
-   amads.algorithms.slice.window
+   amads.algorithms
 
 Pitch
 -----
@@ -82,7 +79,7 @@ Time
 
    amads.time.durdist1
    amads.time.durdist2
-   amads.time.npvi
+   amads.time.variability
    amads.time.swing
    amads.time.tempo
    amads.time.meter.break_it_up
@@ -94,7 +91,7 @@ Harmony
    :toctree: _autosummary
    :caption: Harmony:
 
-   amads.harmony.root_finding.parncutt_1988
+   amads.harmony.root_finding.parncutt
 
 Melody
 ------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,17 +38,18 @@ For the source code, visit the `GitHub repository <https://github.com/music-comp
 
    auto_examples/index
 
-
-
 General algorithms
 ------------------
 
 .. autosummary::
    :toctree: _autosummary
    :caption: General algorithms:
-   :recursive:
 
-   amads.algorithms
+   amads.algorithms.entropy
+   amads.algorithms.nnotes
+   amads.algorithms.scale
+   amads.algorithms.slice.salami
+   amads.algorithms.slice.window
 
 Pitch
 -----


### PR DESCRIPTION
This is currently a stop-gap solution that fixes #119 for `time.npvi` and `harmony.root_finding.parncutt_1988` not being included in the documentation by changing these to `time.variation` and `harmony.root_finding.parncutt` inside `index.rst`.

As I mention [in this comment](https://github.com/music-computing/amads/issues/119#issuecomment-2839407227), I think we should find a way to move away from explicitly defining every package inside `index.rst`.  It doesn't seem that refactoring tools like the one in PyCharm catch these changes properly when the filename of a `.py` file is changed, which makes debugging these issues quite challenging.

I think the solution would be to replace some of the explicit definitions inside `index.rst` with something like the following formulation:

```
General algorithms
------------------

.. autosummary::
   :toctree: _autosummary
   :caption: General algorithms:
   :recursive:

   amads.algorithms
```
