### PR TITLE
Create a draft codemeta.json file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,97 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "applicationCategory": "SoftwareSourceCode,SoftwareApplication",
+    "author": [
+        {
+            "@id": "https://github.com/music-computing",
+            "@type": "Organization"
+        },
+        {
+            "affiliation": {
+                "name": "King's College London",
+                "@type": "Organization"
+            },
+            "email": "mark.gotham@kcl.ac.uk",
+            "familyName": "Gotham",
+            "givenName": "Mark",
+            "@id": "https://orcid.org/0000-0003-0722-3074",
+            "@type": "Person"
+        },
+        {
+            "affiliation": {
+                "name": "Carnegie Mellon University",
+                "@type": "Organization"
+            },
+            "email": "rbd@cs.cmu.edu",
+            "familyName": "Dannenberg",
+            "givenName": "Roger",
+            "@type": "Person"
+        },
+        {
+            "affiliation": {
+                "name": "Cambridge University",
+                "@type": "Organization"
+            },
+            "email": "pmch2@cam.ac.uk",
+            "familyName": "Harrison",
+            "givenName": "Peter",
+            "@type": "Person"
+        }
+    ],
+    "codeRepository": "https://github.com/music-computing/amads",
+    "dateCreated": "2024-02-03",
+    "dateModified": "2026-05-04",
+    "datePublished": "2025-03-30",
+    "description": "A toolkit of algorithms and resources from published literature.",
+    "downloadUrl": "https://github.com/music-computing/amads/releases",
+    "identifier": "amads",
+    "license": "https://spdx.org/licenses/MIT",
+    "name": "amads",
+    "programmingLanguage": "Python",
+    "referencePublication": [
+        {
+            "author": [
+                {
+                    "affiliation": {
+                        "name": "King's College London",
+                        "@type": "Organization"
+                    },
+                    "email": "mark.gotham@kcl.ac.uk",
+                    "familyName": "Gotham",
+                    "givenName": "Mark",
+                    "@id": "https://orcid.org/0000-0003-0722-3074",
+                    "@type": "Person"
+                }
+            ],
+            "datePublished": "2026-03-22",
+            "identifier": "10.5281/zenodo.19182349",
+            "name": "Keeping Score: Computational Methods for the Analysis of Encoded (\"Symbolic\") Musical Scores",
+            "url": "https://zenodo.org/doi/10.5281/zenodo.14938027",
+            "@type": "ScholarlyArticle"
+        }
+    ],
+    "softwareRequirements": [
+        "numpy",
+        "pandas",
+        "matplotlib",
+        {
+            "name": "scipy",
+            "version": ">=1.9"
+        },
+        "partitura",
+        "music21",
+        "pretty_midi",
+        "setuptools",
+        "typing_extensions",
+        "tenacity",
+        "tqdm",
+        "wheel"
+    ],
+    "version": "v1.0.3",
+    "codemeta:contIntegration": {
+        "@id": "https://raw.githubusercontent.com/music-computing/amads/main/.github/workflows/documentation.yml"
+    },
+    "continuousIntegration": "https://raw.githubusercontent.com/music-computing/amads/main/.github/workflows/documentation.yml",
+    "issueTracker": "https://github.com/music-computing/amads/issues",
+    "@type": "SoftwareSourceCode"
+}


### PR DESCRIPTION
Further to the email sent to Dr Mark Gotham last week on behalf of the [CCP-AHC](https://www.ccpahc.ac.uk/) project, I'm opening this pull request to contribute a `codemeta.json` file.
Codemeta is a schema designed to enable software citation by standardising metadata about the project. It is defined and documented at https://codemeta.github.io/.
This pull request creates a file to that standard for this repository, starting from the details automatically filled out by https://autocodemeta.linkeddata.es/ and editing to fill in the gaps the generator is unable to automatically scrape with details manually extracted from the repository and linked pages.

Please do tell me in the discussion where details are inaccurate so that we can bring the codemeta.json file up to date with the project.
