### PR TITLE
Add trim function from Matlab MIDI Toolbox

### DIFF
--- a/amads/algorithms/trim.py
+++ b/amads/algorithms/trim.py
@@ -1,0 +1,45 @@
+"""
+Implementation of the trim() function, which removes leading silence, from the Matlab MIDI Toolbox
+
+Original Document: https://github.com/miditoolbox/1.1/blob/master/documentation/MIDItoolbox1.1_manual.pdf, Page 93
+
+"""
+
+from amads.core.basics import Score
+
+
+def trim(score: Score) -> Score:
+    """
+    Removes all leading silence from a given score such that the first note starts at time 0.0.
+
+    trim() returns a new, flattened score to ensure that the original score is not altered.
+
+    Parameters
+    ----------
+    score: Score
+        The score that is to be trimmed.
+
+    Returns
+    -------
+    Score
+        A new, trimmed, and flattened score.
+
+    """
+    # 1. Get a flattened version of the score
+    flat_score = score.flatten(collapse=True)
+
+    # 2. Get all the notes in the score in sorted order (to get the first note)
+    notes = flat_score.get_sorted_notes()
+
+    # 2a. If it's empty, return it
+    if not notes:
+        return flat_score
+
+    # 3. Calculate how much we need to shift the score.
+    # If the first note starts at time n, we want to shift everything by -n to make it start at time 0.0
+    first_note = notes[0]
+    shift_amount = -first_note.onset
+
+    # 4. Use the time_shift method to move all notes in the score
+    flat_score.time_shift(shift_amount)
+    return flat_score

--- a/amads/algorithms/trim.py
+++ b/amads/algorithms/trim.py
@@ -26,7 +26,7 @@ def trim(score: Score) -> Score:
 
     """
     # 1. Get a flattened version of the score
-    flat_score = score.flatten(collapse=True)
+    flat_score = score.flatten()
 
     # 2. Get all the notes in the score in sorted order (to get the first note)
     notes = flat_score.get_sorted_notes()

--- a/docs/reference/algorithms/trim.md
+++ b/docs/reference/algorithms/trim.md
@@ -1,0 +1,1 @@
+::: amads.algorithms.trim.trim

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - reference/algorithms/scores_compare.md
       - reference/algorithms/scale.md
       - reference/algorithms/slice.md
+      - reference/algorithms/trim.md
     - Schemata: reference/schema.md
   - Install: user_guide/installation.md
   - Developer:

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -1,0 +1,40 @@
+from amads.algorithms.trim import trim
+from amads.core.basics import Note, Part, Score
+
+
+def test_trim():
+    """Test that the trim function correctly shifts the score so the first note starts at 0.0"""
+
+    # Setup our test data
+    my_score = Score()
+    my_part = Part(parent=my_score)
+
+    Note(parent=my_part, onset=6.0, duration=1.0, pitch=60)
+    Note(parent=my_part, onset=7.0, duration=1.0, pitch=10)
+    Note(parent=my_part, onset=8.0, duration=2.0, pitch=20)
+
+    # Run trim() function
+    trimmed_score = trim(my_score)
+    notes = trimmed_score.get_sorted_notes()
+
+    # Verify the results using assert
+
+    # The first note should now be at 0.0
+    assert notes[0].onset == 0.0
+    assert notes[0].pitch.key_num == 60
+
+    # The second note should be at 1.0
+    assert notes[1].onset == 1.0
+    assert notes[1].pitch.key_num == 10
+
+    # The third note should be at 2.0
+    assert notes[2].onset == 2.0
+    assert notes[2].pitch.key_num == 20
+
+    # The original score should be unchanged
+    original_notes = my_score.get_sorted_notes()
+    assert original_notes[0].onset == 6.0
+
+
+if __name__ == "__main__":
+    test_trim()


### PR DESCRIPTION
This PR ports the trim() function from the Matlab MIDI Toolbox, returning a flattened score without modifying the original input. A unit test is also included. 

