### PR TITLE
Ported concur function from MIDI Toolbox

### DIFF
--- a/amads/algorithms/concur.py
+++ b/amads/algorithms/concur.py
@@ -14,7 +14,8 @@ def concur(score: Score, threshold: float = 0.2) -> float:
     the total number of note onsets. Onsets within a certain threshold beats
     are grouped and counted as a single onset.
 
-    This algorithm and its results are not an exact replication of the Matlab MIDI Toolbox concur function.
+    This algorithm and its results are not an exact replication of the
+    Matlab MIDI Toolbox concur function.
 
     Parameters
     ----------
@@ -33,17 +34,16 @@ def concur(score: Score, threshold: float = 0.2) -> float:
     # 1. Get all the notes in the score
     notes = score.get_sorted_notes()
 
-    # 2. Get the onset times of the notes
-    onset_notes = [note.onset for note in notes]
+    # If there are no notes, return 0.0
+    if not notes:
+        return 0.0
 
-    # 3. Group onsets that are within the threshold of each other
-    for i in range(len(onset_notes)):
-        for j in range(i + 1, len(onset_notes)):
-            if abs(onset_notes[i] - onset_notes[j]) <= threshold:
-                onset_notes[j] = onset_notes[i]
+    groups = 1
 
-    # 4. Use a set to get the distinct onsets
-    distinct_onsets = set(onset_notes)
+    # 2. Iterate through the notes and count how many distinct onset groups there are
+    for i in range(1, len(notes)):
+        if notes[i].onset - notes[i - 1].onset > threshold:
+            groups += 1
 
-    # 5. Calculate the ratio of distinct onsets to total onsets
-    return len(distinct_onsets) / len(onset_notes) if onset_notes else 0.0
+    # 3. Calculate the ratio of distinct onsets to total onsets
+    return groups / len(notes)

--- a/amads/algorithms/concur.py
+++ b/amads/algorithms/concur.py
@@ -10,9 +10,14 @@ from amads.core.basics import Score
 
 def concur(score: Score, threshold: float = 0.2) -> float:
     """
-    Calculates the number of distinct note onset times as a fraction of
-    the total number of note onsets. Onsets within a certain threshold beats
-    are grouped and counted as a single onset.
+    Calculates the number of distinct onset "groups," where group
+    boundaries are the inter-onset interval greater than threshold
+    (in beats or seconds, depending on the current units in the score).
+
+    Equivalently, counts the number of distinct onset "groups", where
+    groups are consecutive IOIs less than or equal to threshold. Note
+    that the time span of a group is arbitrary since there can be any
+    number of consecutive IOIs less than threshold.
 
     This algorithm and its results are not an exact replication of the
     Matlab MIDI Toolbox concur function.
@@ -23,27 +28,25 @@ def concur(score: Score, threshold: float = 0.2) -> float:
         The score to analyze.
 
     threshold : float
-        Maximum beat difference between two onsets to be grouped together.
+        IOI in beats greater than this value starts a new group.
         Default value is 0.2.
 
     Returns
     -------
     float
-        The number of distinct onset groups divided by the total number of notes.
+        The number of distinct onset groups divided by the total number
+        of notes.
     """
     # 1. Get all the notes in the score
     notes = score.get_sorted_notes()
+    prev_onset = -999  # effectively -infinity so first note starts a group
+    count = 0
 
-    # If there are no notes, return 0.0
-    if not notes:
-        return 0.0
+    # 2. Iterate through the notes and count distinct onset groups
+    for note in notes:
+        if note.onset - prev_onset > threshold:
+            count += 1
+        prev_onset = note.onset
 
-    groups = 1
-
-    # 2. Iterate through the notes and count how many distinct onset groups there are
-    for i in range(1, len(notes)):
-        if notes[i].onset - notes[i - 1].onset > threshold:
-            groups += 1
-
-    # 3. Calculate the ratio of distinct onsets to total onsets
-    return groups / len(notes)
+    # 3. Calculate the ratio of distinct groups to total notes
+    return count / len(notes)

--- a/amads/algorithms/concur.py
+++ b/amads/algorithms/concur.py
@@ -1,0 +1,49 @@
+"""
+Implementation of the concur() function from the Matlab MIDI Toolbox
+
+Original Document: https://github.com/miditoolbox/1.1/blob/master/documentation/MIDItoolbox1.1_manual.pdf, Page 56
+
+"""
+
+from amads.core.basics import Score
+
+
+def concur(score: Score, threshold: float = 0.2) -> float:
+    """
+    Calculates the number of distinct note onset times as a fraction of
+    the total number of note onsets. Onsets within a certain threshold beats
+    are grouped and counted as a single onset.
+
+    This algorithm and its results are not an exact replication of the Matlab MIDI Toolbox concur function.
+
+    Parameters
+    ----------
+    score : Score
+        The score to analyze.
+
+    threshold : float
+        Maximum beat difference between two onsets to be grouped together.
+        Default value is 0.2.
+
+    Returns
+    -------
+    float
+        The number of distinct onset groups divided by the total number of notes.
+    """
+    # 1. Get all the notes in the score
+    notes = score.get_sorted_notes()
+
+    # 2. Get the onset times of the notes
+    onset_notes = [note.onset for note in notes]
+
+    # 3. Group onsets that are within the threshold of each other
+    for i in range(len(onset_notes)):
+        for j in range(i + 1, len(onset_notes)):
+            if abs(onset_notes[i] - onset_notes[j]) <= threshold:
+                onset_notes[j] = onset_notes[i]
+
+    # 4. Use a set to get the distinct onsets
+    distinct_onsets = set(onset_notes)
+
+    # 5. Calculate the ratio of distinct onsets to total onsets
+    return len(distinct_onsets) / len(onset_notes) if onset_notes else 0.0

--- a/docs/reference/algorithms/concur.md
+++ b/docs/reference/algorithms/concur.md
@@ -1,0 +1,1 @@
+::: amads.algorithms.concur.concur

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - Polyphony:
       - reference/polyphony/skyline.md
     - Algorithms:
+      - reference/algorithms/concur.md
       - reference/algorithms/complexity.md
       - reference/algorithms/entropy.md
       - GCD: reference/algorithms/gcd.md

--- a/tests/test_concur.py
+++ b/tests/test_concur.py
@@ -1,0 +1,49 @@
+from amads.algorithms.concur import concur
+from amads.core.basics import Note, Part, Score
+
+
+def test_concur():
+    """Test that the concur function correctly calculates the proportion of distinct onset groups to total onsets with a given threshold"""
+
+    # 1. Setup our test data
+    test_score = Score()
+    test_part = Part(parent=test_score)
+
+    Note(parent=test_part, onset=0.0, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=0.1, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=0.3, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=1.0, duration=2.0, pitch=60)
+
+    # 2. Run concur() function with a threshold of 0.2
+    concurrency = concur(test_score, threshold=0.2)
+
+    # 3. There are 4 notes and 3 distinct onset groups (0.0 and 0.1 are grouped together, 0.3 is separate, and 1.0 is separate)
+    assert concurrency == 3 / 4
+    print("ok")
+
+
+def test_concur_empty():
+    """Test that concur returns 0.0 for an empty score"""
+    empty_score = Score()
+    Part(parent=empty_score)
+    assert concur(empty_score) == 0.0
+
+
+def test_concur_all_concurrent():
+    """Test that concur returns the correct proportion when all notes are concurrent"""
+    test_score = Score()
+    test_part = Part(parent=test_score)
+
+    Note(parent=test_part, onset=0.0, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=0.1, duration=1.0, pitch=62)
+    Note(parent=test_part, onset=0.15, duration=1.0, pitch=64)
+
+    # All 3 notes are within threshold of each other -> 1 group / 3 notes
+    assert concur(test_score, threshold=0.2) == 1 / 3
+
+
+if __name__ == "__main__":
+    test_concur()
+    test_concur_empty()
+    test_concur_all_concurrent()
+    print("All tests passed!")

--- a/tests/test_concur.py
+++ b/tests/test_concur.py
@@ -36,7 +36,10 @@ def test_concur_all_concurrent():
 
 
 def test_concur_chained():
-    """Test that notes chained within the threshold are grouped into one onset group."""
+    """Test that only notes with IOI within threshold are grouped.
+    Notes at 0.0, 0.15, 0.25 with threshold 0.11. IOI 0.15 > 0.11 so
+    0.0 is its own group, IOI 0.10 <= 0.11 so 0.15 and 0.25 are grouped
+    meaning 2 groups / 3 notes."""
     test_score = Score()
     test_part = Part(parent=test_score)
 
@@ -44,7 +47,7 @@ def test_concur_chained():
     Note(parent=test_part, onset=0.15, duration=1.0, pitch=62)
     Note(parent=test_part, onset=0.25, duration=1.0, pitch=64)
 
-    assert concur(test_score, threshold=0.2) == 1 / 3
+    assert concur(test_score, threshold=0.11) == 2 / 3
 
 
 if __name__ == "__main__":

--- a/tests/test_concur.py
+++ b/tests/test_concur.py
@@ -11,13 +11,14 @@ def test_concur():
 
     Note(parent=test_part, onset=0.0, duration=1.0, pitch=60)
     Note(parent=test_part, onset=0.1, duration=1.0, pitch=60)
-    Note(parent=test_part, onset=0.3, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=0.5, duration=1.0, pitch=60)
     Note(parent=test_part, onset=1.0, duration=2.0, pitch=60)
 
-    # Run concur() function with a threshold of 0.2
+    # Run concur function with a threshold of 0.2
     concurrency = concur(test_score, threshold=0.2)
 
-    # There are 4 notes and 3 distinct onset groups (0.0 and 0.1 are grouped together, 0.3 is separate, and 1.0 is separate)
+    # 0.0 and 0.1 are grouped, 0.5 starts a new group (IOI 0.4 > 0.2),
+    # 1.0 starts a new group (IOI 0.5 > 0.2) so 3 groups / 4 notes
     assert concurrency == 3 / 4
 
 
@@ -34,6 +35,19 @@ def test_concur_all_concurrent():
     assert concur(test_score, threshold=0.2) == 1 / 3
 
 
+def test_concur_chained():
+    """Test that notes chained within the threshold are grouped into one onset group."""
+    test_score = Score()
+    test_part = Part(parent=test_score)
+
+    Note(parent=test_part, onset=0.0, duration=1.0, pitch=60)
+    Note(parent=test_part, onset=0.15, duration=1.0, pitch=62)
+    Note(parent=test_part, onset=0.25, duration=1.0, pitch=64)
+
+    assert concur(test_score, threshold=0.2) == 1 / 3
+
+
 if __name__ == "__main__":
     test_concur()
     test_concur_all_concurrent()
+    test_concur_chained()

--- a/tests/test_concur.py
+++ b/tests/test_concur.py
@@ -5,7 +5,7 @@ from amads.core.basics import Note, Part, Score
 def test_concur():
     """Test that the concur function correctly calculates the proportion of distinct onset groups to total onsets with a given threshold"""
 
-    # 1. Setup our test data
+    # Setup our test data
     test_score = Score()
     test_part = Part(parent=test_score)
 
@@ -14,19 +14,11 @@ def test_concur():
     Note(parent=test_part, onset=0.3, duration=1.0, pitch=60)
     Note(parent=test_part, onset=1.0, duration=2.0, pitch=60)
 
-    # 2. Run concur() function with a threshold of 0.2
+    # Run concur() function with a threshold of 0.2
     concurrency = concur(test_score, threshold=0.2)
 
-    # 3. There are 4 notes and 3 distinct onset groups (0.0 and 0.1 are grouped together, 0.3 is separate, and 1.0 is separate)
+    # There are 4 notes and 3 distinct onset groups (0.0 and 0.1 are grouped together, 0.3 is separate, and 1.0 is separate)
     assert concurrency == 3 / 4
-    print("ok")
-
-
-def test_concur_empty():
-    """Test that concur returns 0.0 for an empty score"""
-    empty_score = Score()
-    Part(parent=empty_score)
-    assert concur(empty_score) == 0.0
 
 
 def test_concur_all_concurrent():
@@ -38,12 +30,10 @@ def test_concur_all_concurrent():
     Note(parent=test_part, onset=0.1, duration=1.0, pitch=62)
     Note(parent=test_part, onset=0.15, duration=1.0, pitch=64)
 
-    # All 3 notes are within threshold of each other -> 1 group / 3 notes
+    # All 3 notes are within threshold of each other
     assert concur(test_score, threshold=0.2) == 1 / 3
 
 
 if __name__ == "__main__":
     test_concur()
-    test_concur_empty()
     test_concur_all_concurrent()
-    print("All tests passed!")


### PR DESCRIPTION
Ports the concur() function from the MIDI Toolbox. Concur calculates the number of distinct onset groups as a fraction of total notes, where onsets within a threshold are grouped together. Includes unit tests and documentation.
  
Note: this is not an exact replication of the original implementation due to inconsistencies. 